### PR TITLE
Issue 9 param validation

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -69,12 +69,17 @@ Workflow creation is not the only area in which Woozie adds value.
 It can also help by checking and validating the workflow you have created.
 
 You can type  =M-x woozie-wf-validate= and it will check whether:
-+ Action names are unique
-+ All transitions are valid
++ Action names are unique;
++ All transitions are valid;
++ All action nodes have an incoming transition.
++ All properties defined in the <parameters> element are unique;
++ All properties defined in the <parameters> element correspond to a variable in the workflow;
++ All variables present in the workflows have a corresponding entry in the <parameters> element. 
 
 You can also check if the workflow with respect to its configuration file.
 Type =M-x woozie-wf-validate-config=, passing the configuration file as a parameter and Emacs will list all 
-the variables in the workflow definition that are missing from the configuration file.
+the variables in the workflow definition that are missing from the configuration file, as well as
+the variables in the config file that are not present in the workflow definition.
 
 
 ** Workflow Visualization

--- a/docs/tutorial.org
+++ b/docs/tutorial.org
@@ -179,10 +179,24 @@ Validating workflow.....
 --- TRANSITION ERRORS!
 ---   bad destination for transition: start -> INSERT_ACTION_NAME_HERE
 ~~~   no transitions exist to node Step1
+Validating parameters....
+7 variables found
+0 parameters found.
+--- PARAMETER WARNINGS:
+--- The following variables do not have a corresponding parameter definition
+--- mydb
+--- mytable
+--- metastore_principal
+--- metastore_uri
+--- queueName
+--- nameNode
+--- jobTracker
 #+END_SRC
 
-Oops! There are errors! Apparently we forgot to edit the start node to add the transition to Step1.
-Not a problem, this can be easily corrected. Once corrected, we run =M-x woozie-wf-validate= again and now get the all clear:
+Oops! There are errors! And warnings! Woozie analysed all transitions and noticed that the
+=start= node has a transition to a non-existent node named =INSERT_ACTION_NAME_HERE=.
+Apparently we forgot to edit the start node to add the transition to Step1.
+:
 
 #+BEGIN_SRC
 =======================================================
@@ -190,9 +204,67 @@ Validating workflow.....
 +++ 6 node names, all unique
 +++ All transitions are valid.
 +++ All nodes have incoming transitions.
+Validating parameters....
+7 variables found
+8 parameters found.
+--- PARAMETER WARNINGS: 
+--- The following properties are defined but not used in this workflow.
+--- mydb
+--- mytable
+--- metastore_principal
+--- metastore_uri
+--- queueName
+--- nameNode
+--- jobTracker
 #+END_SRC
 
-Looks like we are good to go.
+It looks better now, there are no transition errors but we are still getting some
+parameter-related warnings. Woozie is telling us that it found 10 variables in the
+workflow definition, but no corresponding entry in the =<parameters>= tag.
+This is not wrong, as you are not required to list all variables in the parameters section,
+so we are good to go.
+
+We could, if we wanted add the parameters definitions and have that message go away:
+
+#+BEGIN_SRC xml
+  <parameters>
+      <property>
+	  <name>mydb</name>
+      </property>
+      <property>
+	  <name>mytable</name>
+      </property>
+      <property>
+	  <name>metastore_principal</name>
+      </property>
+      <property>
+	  <name>metastore_uri</name>
+      </property>
+      <property>
+	  <name>queueName</name>
+      </property>
+      <property>
+	  <name>nameNode</name>
+      </property>
+      <property>
+	  <name>jobTracker</name>
+      </property>
+  </parameters>
+#+END_SRC
+
+With that snippet, running =M-x woozie-wf-validate= results in the following output:
+
+#+BEGIN_SRC
+=======================================================
+Validating workflow.....
++++ 6 node names, all unique
++++ All transitions are valid.
++++ All nodes have incoming transitions.
+Validating parameters....
+7 variables found
+8 parameters found.
+#+END_SRC
+
 
 * Visualizing Workflows
 

--- a/testdata/sampleworkflow.xml
+++ b/testdata/sampleworkflow.xml
@@ -25,6 +25,21 @@
          </credential>
     </credentials>
 
+    <parameters>
+        <property>
+            <name>param1</name>
+        </property>
+        <property>
+            <name>param2</name>
+            <value>3</value>
+            <description>Something something</description>
+        </property>
+        <property>
+            <name>param1</name>
+            <value>4</value>
+        </property>
+    </parameters>
+    
     <start to="Fork1"/>
 
     <fork name="Fork1">

--- a/woozie.el
+++ b/woozie.el
@@ -53,7 +53,7 @@
   
 (define-derived-mode woozie-mode
   nxml-mode "woozie"
-  "Major mode squpporting Oozie workflow editing."
+  "Major mode supporting Oozie workflow editing."
   )
  
 ;;----------------------------------------------------------------------------------------
@@ -192,6 +192,8 @@
       (woozie--msg "Validating workflow.....")
       (woozie--validate-action-names dom)
       (woozie--validate-action-transitions dom)
+      (woozie--msg "Validating parameters....")
+      (woozie--validate-parameters dom b)
       (switch-to-buffer b))))
 
 (defun woozie-wf-validate-config (config-file)
@@ -409,11 +411,15 @@ Happy path is defined as all traversals reachable from node named 'start'."
   (dolist (elem list)
     (woozie--msg elem)))
   
-(defun woozie--wf-vars-list ()
-  "Return a list of all vars defined in the current buffer."
-  (save-excursion
-    (goto-char (point-min))
-    (cl-remove-if-not 'woozie--valid-wf-var (woozie--find-delimited-from-point "${" "}"))))
+(defun woozie--wf-vars-list (&optional bfer)
+  "Return a list of all vars defined in BFER or the current buffer."
+  (let ( (cb (current-buffer)))
+    (save-excursion
+      (switch-to-buffer (buffer-name bfer))
+      (woozie--msg (concat "buffer in save-excursion:" (buffer-name (current-buffer))))
+      (goto-char (point-min))
+      (cl-remove-if-not 'woozie--valid-wf-var (woozie--find-delimited-from-point "${" "}")))
+    ))
 
 (defun woozie--properties-from-file (config-file)
   "Return a list of the property names defined in CONFIG-FILE."
@@ -461,6 +467,42 @@ Happy path is defined as all traversals reachable from node named 'start'."
 	  (woozie--msg (concat "---    " elem))))
       (woozie--msg (concat "+++ " (number-to-string (length action-names)) " node names, all unique")))))
 
+(defun woozie--validate-parameters (dom b)
+  "Prints a report on the <parameters> section of the DOM and B"
+  (let* ( (param-names (woozie--wf-param-names dom))
+	  (var-names (woozie--wf-vars-list b))
+	  (repeated-names (woozie--list-duplicates param-names))
+	  (unused-names   (cl-set-difference param-names var-names))
+	  (undefined-names (cl-set-difference var-names param-names))
+	  )
+    (woozie--msg (concat (number-to-string (length var-names)) " variables found"))
+    (woozie--msg (concat (number-to-string (length param-names)) " parameters found."))
+    (if repeated-names
+	(progn
+	  (woozie--msg "--- PARAMETER ERRORS!")
+	  (woozie--msg "--- The following properties are defined multiple times")
+	  (dolist (elem repeated-names)
+	    (woozie--msg (concat "---   " elem)))))
+    (if unused-names
+	(progn
+	  (woozie--msg "--- PARAMETER WARNINGS: ")
+	  (woozie--msg "--- The following properties are defined but not used in this workflow.")
+	  (dolist (elem unused-names)
+	    (woozie--msg (concat "---  " elem)))))
+    (if undefined-names
+	(progn
+	  (woozie--msg "--- PARAMETER WARNINGS:")
+	  (woozie--msg "--- The following variables do not have a corresponding parameter definition")
+	  (dolist (elem undefined-names)
+	    (woozie--msg (concat "--- " elem)))))
+  ))
+
+(defun woozie--wf-param-names (dom)
+  "Return a list of values for all /parameters/property/name elements in the DOM."
+  (let ( (parameters-el (car (dom-by-tag dom 'parameters))))
+    (mapcar #'dom-text (dom-by-tag parameters-el 'name) )))
+  
+  
 (defun woozie--wf-is-flow-node-p (node)
   "Return non-nil if NODE participates in a flow."
   (member (dom-tag node) '(start action decision join fork end kill)))
@@ -492,13 +534,6 @@ Flow nodes are all nodes that the workflow can transition through, including `st
   "Return a list with the value of ATTRIB for all NODES in the list."
   (mapcar (lambda (n) (dom-attr n attrib)) nodes))
     
-(defun woozie--find-all-delimited (delim1 delim2 &optional include-dupes)
- "Find all strings delimited by DELIM1 and DELIM2 in the current buffer.
-Non-nil INCLUDE-DUPES allows the returned strings to be duplicates."
-  (save-excursion
-    (goto-char (point-min))
-    (woozie--find-delimited-from-point delim1 delim2 include-dupes)))
-
 (defun woozie--find-delimited-from-point (delim1 delim2 &optional include-dupes)
   "Return a list with all values in the current buffer bounded by DELIM1 and DELIM2.
 Values are unique unless INCLUDE-DUPES is non-nil."

--- a/woozie.el
+++ b/woozie.el
@@ -416,7 +416,6 @@ Happy path is defined as all traversals reachable from node named 'start'."
   (let ( (cb (current-buffer)))
     (save-excursion
       (switch-to-buffer (buffer-name bfer))
-      (woozie--msg (concat "buffer in save-excursion:" (buffer-name (current-buffer))))
       (goto-char (point-min))
       (cl-remove-if-not 'woozie--valid-wf-var (woozie--find-delimited-from-point "${" "}")))
     ))
@@ -472,8 +471,8 @@ Happy path is defined as all traversals reachable from node named 'start'."
   (let* ( (param-names (woozie--wf-param-names dom))
 	  (var-names (woozie--wf-vars-list b))
 	  (repeated-names (woozie--list-duplicates param-names))
-	  (unused-names   (cl-set-difference param-names var-names))
-	  (undefined-names (cl-set-difference var-names param-names))
+	  (unused-names   (cl-set-difference param-names var-names :test #'string=))
+	  (undefined-names (cl-set-difference var-names param-names :test #'string=))
 	  )
     (woozie--msg (concat (number-to-string (length var-names)) " variables found"))
     (woozie--msg (concat (number-to-string (length param-names)) " parameters found."))

--- a/woozie.el
+++ b/woozie.el
@@ -203,7 +203,9 @@ Provides a list of variables not defined in the configuration file."
   (let* ( (b (current-buffer))
 	  (wf-vars (woozie--wf-vars-list) )
 	  (config-vars (woozie--properties-from-file config-file))
-	  (missing-vars (cl-set-difference wf-vars config-vars :test 'string=)))
+	  (missing-vars (cl-set-difference wf-vars config-vars :test #'string=))
+	  (unused-vars (cl-set-difference config-vars wf-vars :test #'string=))
+	  )
     (with-output-to-temp-buffer woozie--msg-buff
       (switch-to-buffer woozie--msg-buff)
       (if missing-vars
@@ -212,6 +214,12 @@ Provides a list of variables not defined in the configuration file."
 	    (dolist (var missing-vars)
 	      (woozie--msg (concat "---   * " var))))
 	(woozie--msg "+++ All workflow variables are defined."))
+      (if unused-vars
+	  (progn
+	    (woozie--msg "--- Unused variable definitions:")
+	    (dolist (var unused-vars)
+	      (woozie--msg (concat "--- * " var))))
+	(woozie--msg "+++ All config properties are used in the workflow."))
       (switch-to-buffer b))))
 
 (defun woozie-wf-show-vars ()

--- a/woozietest.el
+++ b/woozietest.el
@@ -10,13 +10,13 @@
 ;; HELPER FUNCTIONS
 ;;===================================================================================
 (defun string-set= (l1 l2)
-  "returns l1 (or l2) if sets are equal, 'nil otherwise"
+  "Return L1 (or L2) if sets are equal, 'nil otherwise."
   (and (= (length l1) (length l2))
        (not (cl-set-difference l1 l2 :test 'string=))
        (not (cl-set-difference l2 l1 :test 'string=))))
 
 (defun dom-from-file (filename)
-  "creates dom from xml file defined by FILENAME"
+  "Create dom from xml file defined by FILENAME."
   (with-temp-buffer
     (insert-file-contents filename)
     (libxml-parse-xml-region (point-min) (point-max))))
@@ -34,6 +34,11 @@
 ;;===================================================================================
 ;; TESTS
 ;;===================================================================================
+
+(ert-deftest get-parameter-names-test ()
+  "Checks that parameter name extracting function works as expected."
+  (should (equal '("param1" "param2" "param1") (woozie--wf-param-names test-dom))))
+
 
 (ert-deftest list-hive-vars-test ()
   "Make sure that the hive vars are being properly extracted"
@@ -77,7 +82,8 @@
     (insert "This is line {1}\n")
     (insert "This is the {2}nd line.\n")
     (insert "{3}rd line ends it all.")
-    (should (string-set= (woozie--find-all-delimited "{" "}") '("1" "2" "3") ))))
+    (goto-char (point-min))
+    (should (string-set= (woozie--find-delimited-from-point "{" "}") '("1" "2" "3") ))))
 
 (ert-deftest node-names-test ()
   (should (equal (woozie--wf-flow-node-names test-dom)


### PR DESCRIPTION
Adds validations for the `<parameters>` tag of the workflow definition.
Those include:
* checking for duplicates (an error)
* checking that there are no unused parameters (a warning)
* checking whether all variables have corresponding parameter definitions (a warning)