### PR TITLE
Issue 14 cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: purcell/setup-emacs@v3.0
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 28.1
       - name: Run tests
         run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: purcell/setup-emacs@v3.0
-        with: "28.1"
       - name: Run tests
         run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: build-and-test-emacs
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: purcell/setup-emacs@v3.0
+        with: "28.1"
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
Adds CI/CD support to the project. 

Namely, we run `make test` any time something is pushed to any branch