### PR TITLE
Woozie as package

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 
 [[https://oozie.apache.org/][Oozie]] functionality in the emacs environment!
 
-Woozie is an Emacs library with functions that increase Oozie-related productivity.
+Woozie is an Emacs major mode with functions that increase Oozie-related productivity.
 This includes, but is not limited to:
 + functions that simplify building workflow definitions;
 + functions that simplify building workflow configuration files;
@@ -22,14 +22,11 @@ To run unit tests for this code: =make=
 
 ** Installation
 
-Installation is straightforward. Just copy the file =woozie.el= to your machine and add the following to your emacs configuration:
+Installation is straightforward. Download =woozie.el= to your computer and, inside Emacs,
+run =package-install-file=, passing the path to the downloaded file as a parameter.
+Enable =woozie-mode= when you are ready to edit your workflow definition file and you are good
+to go.
 
-#+BEGIN_SRC emacs-lisp
-(load-file "path/to/woozie.el")
-#+END_SRC
-
-All functions start with `woozie-`, so feel free to use =C-h f woozie-<TAB>= to explore
-the available functionality.
 
 
 

--- a/docs/index.org
+++ b/docs/index.org
@@ -2,26 +2,24 @@
 
 * Overview
 
-Woozie is a collection of emacs-lisp functions that aid in the creation and maintenance of Oozie workflows.
-This library makes it easier to create workflow definitions and corresponding configuration files.
+Woozie is an Emacs package that aids in the creation and maintenance of Oozie workflows.
+Its associated major mode, =woozie-mode= provides functionality for creating and validating workflow
+definitions as well as extracting parameters into properties files.
 It can also be used to validate workflows.
 
-* Environment Setup
+* Installation
+
+Setting up is straightforward:
+1. Download =woozie.el= to your machine.
+2. Start Emacs.
+3. Run =M-x package-install-file= and pass the path to where =woozie.el= was downloaded.
 
 
-Setting up Emacs to use this library is trivial.  All you have to do is download  =woozie.el= to your machine.
-Then copy it to where you want it reside and add the following to your emacs configuration file (usually =.emacs= or =.emacs.d/init.el=):
-
-#+BEGIN_SRC emacs-lisp
-(load-file "path/to/woozie.el")
-#+END_SRC
-
-And that is all there is to it. 
-Several functions starting with =woozie-= are now available to aid you in creating, visualizing and validating Oozie workflows.
+And that is all, you are good to go.
 
 * Woozie Mode
 
-Once the file is loaded, you can open a buffer where you will build your workflow XML definition and type =M-x woozie-mode=
+Once the package is installed, you can open a buffer where you will build your workflow XML definition and type =M-x woozie-mode=
 which will set woozie-mode as the buffer's major mode.
 This mode is an extension of the nXML mode included with Emacs for XML processing and extends it with key bindings for
 creating, validating and visualizing workflows.
@@ -187,8 +185,10 @@ Running it on our example workflow resulted in the figure below:
 
 * What Is Coming Next?
 
-Woozie still has a lot of room to grow. New features currently planned include:
+Woozie still has a lot of room to grow. Some of the things we are thinking of are:
 + User-defined templates for the different xml elements;
 + Improving ASCII visualization capabilities to include if-conditionals and fork/join;
-+ Oozie cli commands for workflow management.
++ Functions for installing, starting and monitoring workflows
+
+Check the [[https://github.com/target/woozie/issues][repo's issue section]] to see what we are working on, and add your own requests!
 

--- a/docs/tutorial.org
+++ b/docs/tutorial.org
@@ -15,13 +15,10 @@ Woozie will help you not only with workflow and property file creation, but will
 * Setup
 
 Before you can start using Woozie, you have to download it from the [[https://git.target.com/DSEIncubator/Woozie][git repo]].
-The easiest way is to just copy =woozie.el= over to your =~/.emacs.d= directory and add the following to your initialization script:
+The easiest way is to just copy =woozie.el= over to your =~/.emacs.d= directory and install it via the =M-x package-install-file= command
+once you start Emacs.
 
-#+BEGIN_SRC emacs-lisp
-  (load "~/.emacs.d/woozie.el")
-#+END_SRC
-
-Once the file is loaded, you will have a collection of functions, all starting with =woozie-= that will help you create, validate and visualize workflow definitions.
+Once the pacakge is installed, you will have a new major mode for editing Oozie workflow defintion files.
 Create a buffer where you want to work on your workflow definition, set it to woozie mode by typing =M-x woozie-mode=
 and you are good to go.
 

--- a/woozie.el
+++ b/woozie.el
@@ -1,19 +1,22 @@
-;;; woozie -- Summary
+;;; woozie.el --- Utilities for creating Oozie workflows
 ;; -*- lexical-binding: t; -*-
-;; Copyright (c) 2016-2021, Target Corp.
+;;
+;; Copyright (c) 2016-2022 Target Corp.
 ;;
 ;; Authors: alexandre.santoro@target.com
-
-;; Version: 0.2.0
+;; Version: 0.3.0
+;; Package-Requires: ((emacs "27.2"))
+;; Keywords: Oozie, workflow
+;; URL: https://github.com/target/woozie
 
 ;;; Commentary:
 ;;
-;; ooziefuncs contains a collection of functions that simplify creating oozie workflows.
-;; These include functions for:
-;;    * adding actions tot the current workflow.xml buffer
-;;    * extracting variable information from one (or more) workflow.xml files and adding
-;;      them to a config buffer, which can then serve as the basis for creating a confi-
-;;      guration file.
+;; Woozie defines a collection of functions that simplify creating oozie workflows.
+;; Capabilties include:
+;;    * Insertion of workflow XML elements via commands
+;;    * Workflow definition validation;
+;;    * Easy extraction of paramaeters for properties file creation
+;;    * Validation of property files against workflows (indicates unused and missing values)
 ;;    * generating graph representations of the workflow
 ;;
 ;;; Code:
@@ -50,7 +53,8 @@
     (define-key map "\C-c\C-wd" 'woozie-wf-view-dag)
     map
     ))
-  
+
+;;;###autoload
 (define-derived-mode woozie-mode
   nxml-mode "woozie"
   "Major mode supporting Oozie workflow editing."


### PR DESCRIPTION
Wraps woozie.el as an emacs package that can be installed via the `package-install-file` command. 

Closes #18 